### PR TITLE
DEV: Migrate from {{user-selector}} to {{email-group-user-chooser}}

### DIFF
--- a/assets/javascripts/discourse/templates/fingerprint-report.hbs
+++ b/assets/javascripts/discourse/templates/fingerprint-report.hbs
@@ -6,12 +6,13 @@
       </div>
 
       <div class="section-body">
-        {{user-selector
-          single=true
-          usernames=username
-          onChangeCallback=(action "onChange")
-          placeholderKey="user.username.title"
-          canReceiveUpdates="true"
+        {{email-group-user-chooser
+          value=username
+          onChange=(action "updateUsername")
+          options=(hash
+            maximum=1
+            filterPlaceholder="user.username.title"
+          )
         }}
       </div>
     </div>


### PR DESCRIPTION
I already migrated this plugin in https://github.com/discourse/discourse-fingerprint/commit/120677485bce0dd089525a1e25ee75e9aca1a3be, but somehow https://github.com/discourse/discourse-fingerprint/commit/12ef0b86a50f898ca6b96e9d9b2f69e9ec439514 reverted my changes to the `fingerprint-report.hbs` file and now it's back to `{{user-selector}}`.